### PR TITLE
feat(Chef AI): Cookbook's Chef AI agent integration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,7 +214,6 @@ plugins:
         'agglayer/core-concepts/migration_guide.md': 'agglayer/core-concepts/index.md'
         'agglayer/core-concepts/ECDSA-vs-FEP.md': 'agglayer/core-concepts/index.md'
         'agglayer/core-concepts/v0.2_vs_v0.3.md': 'agglayer/core-concepts/index.md'
-
 validation:
   absolute_links: warn
   anchors: warn

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,6 +6,10 @@
     <meta name="google-site-verification" content="sALqmNQZWZ6_5ig5JqIaFiR6AMUotcGG6xFq_fQPt_U" />
     <!-- End of verification for Google search -->
 
+    <!-- Chef AI -->
+  <script src="https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js" defer></script>
+    <!-- End Chef AI -->
+
 {% endblock %}
 
 {% block scripts %}
@@ -15,5 +19,10 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MQWH3L28"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+
+    <!-- Chef AI -->
+     <div id="__cookbook" data-api-key="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2OGIwZGI4MjM0ZWM1OGQ5MjUyNTU0YjgiLCJpYXQiOjE3NTY0MjA5OTQsImV4cCI6MjA3MTk5Njk5NH0.NyQiKbz8J_-k4sngxoWpB2L_FAKrFgegXf_GTtUzLjU" ></div>
+    <!-- End Chef AI -->
+     
     
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ mkdocs-open-in-new-tab==1.0.3
 mkdocs-multirepo-plugin==0.7.0
 mkdocs-redirects==1.2.1
 mkdocs-mermaid2-plugin==1.1.1
+pyyaml-env-tag==1.1
+


### PR DESCRIPTION
## Preview
Preview link: https://docsbot-demo-git-agglayer-cookbookdev.vercel.app/

## Ask Cookbook AI Assistant
Cookbook's Ask Cookbook AI assistant and co-pilot is trained on all existing Agglayer resources (source code, docs website, etc.) and is available as a standalone modal, embeddable as a button on any page (recommended for technical docs). It answers developer questions about using Agglayer, acting as an enhanced and streamlined technical documentation search tool as well as a Solidity coding co-pilot.

Ask Cookbook AI can also access context from thousands of data sources indexed by Cookbook.dev in addition to Agglayer-specific data sources, providing the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

<img width="5088" height="3368" alt="image" src="https://github.com/user-attachments/assets/5573aad7-eed0-457d-89e1-1911436f6a81" />
  