### PR TITLE
Redirect all traffic to docs.polygon.technology/interoperability/agglayer

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,17 +2,5 @@ server {
     listen 3000;
     server_name _;
 
-    root /usr/share/nginx/html;
-    index index.html;
-
-    location / {
-        root /usr/share/nginx/html;
-        index index.html;
-        try_files $uri $uri/ /index.html;
-    }
-
-    error_page 404 /404.html;
-    location = /404.html {
-        internal;
-    }
+    return 301 https://docs.polygon.technology/interoperability/agglayer;
 }


### PR DESCRIPTION
## Summary
- Replace the static-file nginx config in [nginx.conf](nginx.conf) with a catch-all `return 301 https://docs.polygon.technology/interoperability/agglayer;`
- Every request path (homepage, `/agglayer/*`, `/cdk/*`, `/vault-bridge/*`, asset URLs, unknown paths) now permanently redirects to the new Agglayer docs home on the Polygon docs site
- No changes to the MkDocs build, Dockerfile, or deploy workflows — rollback is a single revert of this file

## Why
Agglayer documentation is moving to the Polygon docs. The existing `mkdocs-redirects` plugin only supports in-site path-to-path redirects, so it can't redirect to an external host. An nginx 301 is the right primitive: one rule covers all ~95 pages, returns a proper `301 Moved Permanently` for SEO/crawlers, and is identical across the ECS and GCP deployment targets.
